### PR TITLE
Update config.yml

### DIFF
--- a/connector/src/main/resources/config.yml
+++ b/connector/src/main/resources/config.yml
@@ -89,15 +89,15 @@ command-suggestions: true
 
 # The following three options enable "ping passthrough" - the MOTD, player count and/or protocol name gets retrieved from the Java server.
 # Relay the MOTD from the remote server to Bedrock players.
-passthrough-motd: false
+passthrough-motd: true
 # Relay the protocol name (e.g. BungeeCord [X.X], Paper 1.X) - only really useful when using a custom protocol name!
 # This will also show up on sites like MCSrvStatus. <mcsrvstat.us>
-passthrough-protocol-name: false
+passthrough-protocol-name: true
 # Relay the player count and max players from the remote server to Bedrock players.
-passthrough-player-counts: false
+passthrough-player-counts: true
 # Enable LEGACY ping passthrough. There is no need to enable this unless your MOTD or player count does not appear properly.
 # This option does nothing on standalone.
-legacy-ping-passthrough: false
+legacy-ping-passthrough: true
 # How often to ping the remote server, in seconds. Only relevant for standalone or legacy ping passthrough.
 # Increase if you are getting BrokenPipe errors.
 ping-passthrough-interval: 3


### PR DESCRIPTION
I will in no way be offended if this is not merged. Essentially, it makes Geyser slightly more configured at the start for plugin versions by forwarding more information about the server to Bedrock players.